### PR TITLE
docs : Modify Typo in the exception message.

### DIFF
--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -23,7 +23,7 @@ Renderer::Renderer(const RendererSettings &settings) :
 
     _animationScene = Scene::load(settings.filenameAnimation);
     if (_animationScene.cameraKeyframes.size() != 2) {
-        throw Exception("Provide exactly too camera keyframes!");
+        throw Exception("Provide exactly two camera keyframes!");
     }
     _startCamera = _animationScene.cameraKeyframes[0];
     _endCamera = _animationScene.cameraKeyframes[1];


### PR DESCRIPTION
Animation Scene file must have "**two**" camera key frames. 
With this fact, I think it is typo in the message "Provide exactly too camera keyframes!"